### PR TITLE
Fixed invalid suffix on literal warning

### DIFF
--- a/src/Z80_Simulator.cpp
+++ b/src/Z80_Simulator.cpp
@@ -1888,7 +1888,7 @@ int main(int argc, char *argv[])
    if (verbous)
    {
       printf("---------------------\n");
-      printf("Duration: %"PRId64"ms\n\n", duration);
+      printf("Duration: %" PRId64 "ms\n\n", duration);
    }
    duration = GetTickCount();
 
@@ -2769,7 +2769,7 @@ int main(int argc, char *argv[])
 
    duration = GetTickCount() - duration;
    printf("---------------------\n");
-   printf("Duration: %"PRId64"ms\n", duration);
+   printf("Duration: %" PRId64 "ms\n", duration);
    printf("Speed of simulation: %.2fHz\n", (double(totcycles) / 2.0) / double(duration) * 1000.0 / double(DIVISOR));
 
    if (outfile)


### PR DESCRIPTION
Fixed this build warning in Linux (Mint 19) as described here: https://github.com/konstantinmiller/dashp2p/issues/3