### PR TITLE
Make Windows MSVC 2015 build solution

### DIFF
--- a/include/png++/error.hpp
+++ b/include/png++/error.hpp
@@ -32,7 +32,7 @@
 #define PNGPP_ERROR_HPP_INCLUDED
 
 /* check if we have strerror_s or strerror_r, prefer the former which is C11 std */
-#ifdef __STDC_LIB_EXT1__
+#if defined(__STDC_LIB_EXT1__) || defined(WINDOWS)
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
 

--- a/msvc/README.txt
+++ b/msvc/README.txt
@@ -1,0 +1,20 @@
+Visual Studio 2015 (and newer)
+==============================
+
+Only 64-bit configuration is provided (debug/relase).
+
+Install libpng with MS vcpkg tool: https://docs.microsoft.com/en-us/cpp/build/vcpkg?view=vs-2019
+
+ vcpkg install libpng:x64-windows
+ vcpkg integrate install
+
+Open msvc/Z80Simulator.sln in the IDE.
+You probably want to switch to "Release" configuration for performance reasons.
+
+Project Properties -> Debugging -> Command Arguments, set to "Z80"
+Project Properties -> Debugging -> Working Directory, set to ".."
+
+If you just want to build the solution on the command line, use this command
+(from the VS2015 Developer Command Prompt):
+
+ msbuild Z80Simulator.sln /property:Configuration=Release

--- a/msvc/Z80Simulator.sln
+++ b/msvc/Z80Simulator.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Z80Simulator", "Z80Simulator.vcxproj", "{F56A1588-6A71-4F43-9C5A-E7D0A7E4D365}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Release|x64 = Release|x64
+		Debug|x64 = Debug|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F56A1588-6A71-4F43-9C5A-E7D0A7E4D365}.Release|x64.ActiveCfg = Release|x64
+		{F56A1588-6A71-4F43-9C5A-E7D0A7E4D365}.Release|x64.Build.0 = Release|x64
+		{F56A1588-6A71-4F43-9C5A-E7D0A7E4D365}.Debug|x64.ActiveCfg = Debug|x64
+		{F56A1588-6A71-4F43-9C5A-E7D0A7E4D365}.Debug|x64.Build.0 = Debug|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/msvc/Z80Simulator.vcxproj
+++ b/msvc/Z80Simulator.vcxproj
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{F56A1588-6A71-4F43-9C5A-E7D0A7E4D365}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Z80Simulator</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <IncludePath>../include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
+    <ExecutablePath>$(ExecutablePath)</ExecutablePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>../include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WINDOWS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>zlibd.lib;libpng16d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <StackReserveSize>41943040</StackReserveSize>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WINDOWS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>libpng16.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <StackReserveSize>4194304</StackReserveSize>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\src\Z80_Simulator.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/Z80_Simulator.cpp
+++ b/src/Z80_Simulator.cpp
@@ -1792,7 +1792,15 @@ int main(int argc, char *argv[])
    // ================================================================
    // ================================================================
 
-/* for (unsigned int i = 0; i < pads.size(); i++)
+   // Write out the layermap file as 3 individual layers containing a net number for each coordinate
+   int bytes = size_x * size_y * sizeof(uint16_t);
+   FILE* file = fopen("layermap.bin", "wb");
+   fwrite(signals_diff, 1, bytes, file);
+   fwrite(signals_poly, 1, bytes, file);
+   fwrite(signals_metal, 1, bytes, file);
+   fclose(file);
+
+   /* for (unsigned int i = 0; i < pads.size(); i++)
    {
       printf("*** Pad at x:%d y:%d signal:%d cons:%d type:%s\n",
          pads[i].x, pads[i].y, pads[i].origsignal, pads[i].connections.size(), (pads[i].type == PAD_INPUT ? "I" : ((pads[i].type == PAD_OUTPUT) ? "O" : "B")));

--- a/src/Z80_Simulator.cpp
+++ b/src/Z80_Simulator.cpp
@@ -20,7 +20,11 @@
 
 #include <png++/png.hpp>
 
+#if !defined(WINDOWS)
 #include <sys/time.h>
+#else
+#include <Windows.h>
+#endif
 
 using namespace std;
 
@@ -40,12 +44,14 @@ uint16_t stack_layer[FILL_STACK_SIZE];
 
 #define ZeroMemory(p, sz) memset((p), 0, (sz))
 
+#if !defined(WINDOWS)
 uint64_t GetTickCount()
 {
    timeval tv;
    gettimeofday(&tv, NULL);
    return  tv.tv_sec * 1000LL + tv.tv_usec / 1000;
 }
+#endif
 
 #ifdef DMB_THREAD
 unsigned int thread_count = 3;


### PR DESCRIPTION
This adds back Windows MSVC 2015 build configuration in a minimally disruptive way.
Tested on Windows 10, x64.